### PR TITLE
Record dot rewrite

### DIFF
--- a/src/Images.hs
+++ b/src/Images.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE NoFieldSelectors #-}
 
 module Images
   ( createImageTable,
@@ -72,7 +74,7 @@ storeImageInDB db imageFolder imageTitle image rId = do
   return randomUUID
 
 getImageUUIDsForRecipe :: Connection -> RecipeID -> IO [UUID]
-getImageUUIDsForRecipe db rId = map uuid <$> query db "SELECT * FROM images WHERE recipeId = ?;" (Only rId)
+getImageUUIDsForRecipe db rId = map (.uuid) <$> (query db "SELECT * FROM images WHERE recipeId = ?;" (Only rId) :: IO [ImageInfo])
 
 handleGetImage :: FilePath -> ActionM ()
 handleGetImage imageFolder = do

--- a/src/Ingredients.hs
+++ b/src/Ingredients.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE NoFieldSelectors #-}
 
 module Ingredients (createIngredientsTables, handleGetIngredients, handleGetIngredient, handleCreateIngredient, handleGetRecipeIngredients, handleAddRecipeIngredient) where
 
@@ -138,9 +140,9 @@ handleAddRecipeIngredient :: Connection -> ActionT Lazy.Text IO ()
 handleAddRecipeIngredient db = do
   requestedId <- param "recipeId" :: ActionM Int
   requestData <- jsonData :: ActionM AddIngredientRequest
-  case nameToUnit . reqUnit $ requestData of
+  case nameToUnit . (.reqUnit) $ requestData of
     Just measUnit -> do
-      added <- liftIO $ addIngredientToRecipe db (reqIngredientTypeId requestData) requestedId $ IngredientQuantity measUnit (Just . reqAmount $ requestData)
+      added <- liftIO $ addIngredientToRecipe db requestData.reqIngredientTypeId requestedId $ IngredientQuantity measUnit (Just requestData.reqAmount)
       if added
         then raiseStatus status201 "Added ingredient to recipe"
         else raiseStatus status409 "Ingredient already exists in recipe"
@@ -168,5 +170,5 @@ instance FromJSON CreateIngredientRequest where
 handleCreateIngredient :: Connection -> ActionT Lazy.Text IO ()
 handleCreateIngredient db = do
   createRequest <- jsonData :: ActionM CreateIngredientRequest
-  liftIO $ createIngredientType db $ name createRequest
+  liftIO $ createIngredientType db createRequest.name
   raiseStatus status201 "Created ingredient type"

--- a/src/Ingredients.hs
+++ b/src/Ingredients.hs
@@ -130,7 +130,7 @@ handleGetRecipeIngredients db = do
   ingredients <- liftIO $ getIngredientsOfRecipe db requestedId
   json ingredients
 
-data AddIngredientRequest = AddIngredientRequest {reqIngredientTypeId :: Int, reqUnit :: Text, reqAmount :: Int}
+data AddIngredientRequest = AddIngredientRequest {ingredientTypeId :: Int, unit :: Text, amount :: Int}
 
 instance FromJSON AddIngredientRequest where
   parseJSON (Object o) = AddIngredientRequest <$> o .: "ingredientTypeId" <*> o .: "measurementUnit" <*> o .: "ingredientAmount"
@@ -140,9 +140,9 @@ handleAddRecipeIngredient :: Connection -> ActionT Lazy.Text IO ()
 handleAddRecipeIngredient db = do
   requestedId <- param "recipeId" :: ActionM Int
   requestData <- jsonData :: ActionM AddIngredientRequest
-  case nameToUnit . (.reqUnit) $ requestData of
+  case nameToUnit . (.unit) $ requestData of
     Just measUnit -> do
-      added <- liftIO $ addIngredientToRecipe db requestData.reqIngredientTypeId requestedId $ IngredientQuantity measUnit (Just requestData.reqAmount)
+      added <- liftIO $ addIngredientToRecipe db requestData.ingredientTypeId requestedId $ IngredientQuantity measUnit (Just requestData.amount)
       if added
         then raiseStatus status201 "Added ingredient to recipe"
         else raiseStatus status409 "Ingredient already exists in recipe"

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE NoFieldSelectors #-}
+
 
 module Main (main) where
 
@@ -36,9 +39,9 @@ main = do
   let config = fromMaybe ServerConfig {port = 3000, adminPassword = "admin", imageFolder = "images"} (decode configBytes)
   db <- open "recipes.sqlite"
   createTables db
-  adminSuccess <- createUser db "admin" (adminPassword config)
+  adminSuccess <- createUser db "admin" config.adminPassword
   when adminSuccess $ putStrLn "Created user \"admin\""
-  scotty (port config) $ do
+  scotty config.port $ do
     post "/register" $ handleRegister db
     post "/login" $ handleLogin db
     get "/ingredients" $ handleGetIngredients db
@@ -51,4 +54,4 @@ main = do
     get "/recipes/:recipeId/ingredients" $ handleGetRecipeIngredients db
     post "/recipes/:recipeId/ingredients" $ handleAddRecipeIngredient db
     get "/recipes/:recipeId/images" $ handleGetAssociatedImageUUIDs db
-    get "/images/:uuid" $ handleGetImage (imageFolder config)
+    get "/images/:uuid" $ handleGetImage config.imageFolder

--- a/src/Recipe.hs
+++ b/src/Recipe.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE NoFieldSelectors #-}
+
 
 module Recipe
   ( createRecipeTable,
@@ -129,7 +132,7 @@ getAllRecipes :: Connection -> IO [RecipeWithID]
 getAllRecipes = flip query_ "SELECT * FROM recipes;"
 
 getRecipe :: Connection -> RecipeID -> IO (Occurence Recipe)
-getRecipe db recipeID = occurences . map recipe <$> query db "SELECT * FROM recipes WHERE id = ?;" (Only recipeID)
+getRecipe db recipeID = occurences . map (.recipe) <$> (query db "SELECT * FROM recipes WHERE id = ?;" (Only recipeID) :: IO [RecipeWithID])
 
 addRecipe :: Connection -> Recipe -> IO ()
 addRecipe db recipeToAdd = do

--- a/src/User.hs
+++ b/src/User.hs
@@ -9,7 +9,6 @@ module User (handleRegister, handleLogin, createUser) where
 
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Aeson
-import Data.Aeson.Types
 import Data.Int
 import Data.Maybe
 import Data.Password.Bcrypt
@@ -38,17 +37,13 @@ data DbUser = DbUser {userId :: Int, username :: Text, passwordHash :: Text} der
 
 instance FromRow DbUser
 
-data RegisterRequest = RegisterRequest {username :: Text, password :: Text}
+data RegisterRequest = RegisterRequest {username :: Text, password :: Text} deriving (Generic)
 
 instance FromJSON RegisterRequest where
-  parseJSON (Object o) = RegisterRequest <$> o .: "username" <*> o .: "password"
-  parseJSON other = prependFailure "Parsing Register Request failed: " (typeMismatch "Object" other)
 
-data LoginRequest = LoginRequest {username :: Text, password :: Text}
+data LoginRequest = LoginRequest {username :: Text, password :: Text} deriving (Generic)
 
 instance FromJSON LoginRequest where
-  parseJSON (Object o) = LoginRequest <$> o .: "username" <*> o .: "password"
-  parseJSON other = prependFailure "Parsing Credentials failed: " (typeMismatch "Object" other)
 
 findUser :: Connection -> Text -> IO (Occurence DbUser)
 findUser db name = do

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE NoFieldSelectors #-}
 
 module Util (Occurence (None, One, Many), occurences, maybeOccurs, getTimeSinceEpoch, extractCookie) where
 
@@ -22,16 +24,16 @@ maybeOccurs None = Nothing
 maybeOccurs Many = Nothing
 maybeOccurs (One v) = Just v
 
-data Cookie = Cookie {cookieName :: Text, cookieValue :: Text} deriving (Show)
+data Cookie = Cookie {name :: Text, cookieValue :: Text} deriving (Show)
 
 makeCookieFromList :: [Text] -> Cookie
 makeCookieFromList [a, b] = Cookie a b
 makeCookieFromList _ = error "Failure constructing cookie from key-value-pair"
 
 extractCookie :: Text -> Text -> Maybe Text
-extractCookie cookie cookies = do
+extractCookie cookieName cookies = do
   let cookieList = makeCookieFromList . Data.Text.splitOn "=" . Data.Text.strip <$> Data.Text.splitOn ";" cookies
-   in cookieValue <$> Data.List.find ((== cookie) . cookieName) cookieList
+   in (.cookieValue) <$> Data.List.find (\cookie -> cookie.name == cookieName) cookieList
 
 getTimeSinceEpoch :: IO Int64
 getTimeSinceEpoch = do


### PR DESCRIPTION
The entire codebase now uses the Language Extension "OverloadedRecordDots" for record field access. This change got proposed because of many conflicting field names.